### PR TITLE
fixed named collision

### DIFF
--- a/nac/workflows/initialization.py
+++ b/nac/workflows/initialization.py
@@ -166,7 +166,7 @@ def split_trajectory(path: str, nBlocks: int, pathOut: str) -> list:
     if err:
         raise RuntimeError("Submission Errors: {}".format(err))
     else:
-        return fnmatch.filter(os.listdir(), "chunk_xyz*")
+        return fnmatch.filter(os.listdir(), "chunk_xyz_?")
 
 
 def log_config(workdir, path_hdf5, algorithm):


### PR DESCRIPTION
If the name of the trajectory and a `chunk` file trajectory are similar there is a collision in the namespace