### PR TITLE
compute_oscillator_every to stride #125

### DIFF
--- a/nac/workflows/schemas.py
+++ b/nac/workflows/schemas.py
@@ -1,5 +1,6 @@
 __all__ = [
     'schema_cp2k_general_settings', 'schema_derivative_couplings',
+    'schema_distribute_absorption_spectrum',
     'schema_distribute_derivative_couplings',
     'schema_absorption_spectrum']
 
@@ -176,7 +177,7 @@ dict_absorption_spectrum = {
     Optional("energy_range", default=[0, 5]): Schema([Real, Real]),
 
     # Interval between MD points where the oscillators are computed"
-    Optional("calculate_oscillator_every",  default=50): int,
+    Optional("stride",  default=50): int,
 
     # description: Exchange-correlation functional used in the DFT calculations,
     Optional("xc_dft", default="pbe"): str,
@@ -192,7 +193,6 @@ dict_absorption_spectrum = {
 
 dict_merged_absorption_spectrum = merge(dict_general_options, dict_absorption_spectrum)
 
-# define schema
 schema_absorption_spectrum = Schema(dict_merged_absorption_spectrum)
 
 
@@ -211,10 +211,8 @@ dict_distribute_absorption_spectrum = {
     "job_scheduler": schema_job_scheduler,
 
     # General settings
-    "cp2k_general_settings": schema_cp2k_general_settings,
-
+    "cp2k_general_settings": schema_cp2k_general_settings
 }
 
-# define distribute schema
 schema_distribute_absorption_spectrum = Schema(
     merge(dict_merged_absorption_spectrum, dict_distribute_absorption_spectrum))

--- a/nac/workflows/workflow_stddft_spectrum.py
+++ b/nac/workflows/workflow_stddft_spectrum.py
@@ -44,7 +44,7 @@ def workflow_stddft(config: dict) -> None:
     results = gather(
        *[scheduleTDDFT(config, mo_paths_hdf5[i], {'i': i, 'mol': mol})
          for i, mol in enumerate(molecules_au)
-         if (i % config.calculate_oscillator_every) == 0])
+         if (i % config.stride) == 0])
 
     return run(results, folder=config['workdir'])
 

--- a/scripts/distribution/distribute_jobs.py
+++ b/scripts/distribution/distribute_jobs.py
@@ -111,10 +111,6 @@ def distribute_computations(config: dict, hamiltonians=False) -> None:
         config['enumerate_from'] += dict_input.dim_batch
 
 
-def distribute_computations_absorption_spectrum(config: dict) -> None:
-    pass
-
-
 def write_input(folder_path: str, config: dict) -> None:
     """ Write the python script to compute the PYXAID hamiltonians"""
     file_path = join(folder_path, "input.yml")
@@ -137,7 +133,12 @@ def write_input(folder_path: str, config: dict) -> None:
               'workdir']:
         del config[k]
 
-    config['workflow'] = "derivative_couplings"
+    # rename the workflow to execute
+    workflow_type = config["workflow"].lower()
+    if workflow_type == "distribute_derivative_couplings":
+        config['workflow'] = "derivative_couplings"
+    elif workflow_type == "distribute_absorption_spectrum":
+        config['workflow'] = "absorption_spectrum"
     with open(file_path, "w") as f:
         yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
 

--- a/test/test_files/input_test_distribute_absorption_spectrum.yml
+++ b/test/test_files/input_test_distribute_absorption_spectrum.yml
@@ -6,7 +6,7 @@ xc_dft:  pbe
 tddft: stda
 active_space:
   [10, 10]
-calculate_oscillator_every:
+stride:
   50
 path_hdf5:
   "test/test_files/Cd33Se33.hdf5"


### PR DESCRIPTION
 changes:
 * renamed `compute_oscillator_every` to stride
 * When calling the `distribute_job` script name the workflows either `absorption_spectrum` or `derivative_coupling`